### PR TITLE
Fix parsing app expression and remove all s/r conflicts

### DIFF
--- a/parser.mly
+++ b/parser.mly
@@ -38,6 +38,7 @@ let addtyp x = (x, Type.gentyp ())
 %token EOF
 
 /* (* 優先順位とassociativityの定義（低い方から高い方へ） (caml2html: parser_prior) *) */
+%nonassoc IN
 %right prec_let
 %right SEMICOLON
 %right prec_if

--- a/parser.mly
+++ b/parser.mly
@@ -119,7 +119,7 @@ exp: /* (* ∞Ï»Ã§Œº∞ (caml2html: parser_exp) *) */
 | LET REC fundef IN exp
     %prec prec_let
     { LetRec($3, $5) }
-| exp actual_args
+| simple_exp actual_args
     %prec prec_app
     { App($1, $2) }
 | elems

--- a/parser.mly
+++ b/parser.mly
@@ -42,6 +42,7 @@ let addtyp x = (x, Type.gentyp ())
 %right SEMICOLON
 %right prec_if
 %right LESS_MINUS
+%nonassoc prec_tuple
 %left COMMA
 %left EQUAL LESS_GREATER LESS GREATER LESS_EQUAL GREATER_EQUAL
 %left PLUS MINUS PLUS_DOT MINUS_DOT
@@ -123,6 +124,7 @@ exp: /* (* ∞Ï»Ã§Œº∞ (caml2html: parser_exp) *) */
     %prec prec_app
     { App($1, $2) }
 | elems
+    %prec prec_tuple
     { Tuple($1) }
 | LET LPAREN pat RPAREN EQUAL exp IN exp
     { LetTuple($3, $6, $8) }


### PR DESCRIPTION
I found callee of `app` operator should be `simple_exp`. As a bonus of this fix, s/r conflicts are reduced from 135 to 15.

FWIW, OCaml implementation also use `simple_expr` for callee of apply expression.

https://github.com/ocaml/ocaml/blob/fd0dc6a0fbf73323c37a73ea7e8ffc150059d6ff/parsing/parser.mly#L1314

And I fixed another s/r conflict around `COMMA` (reduced 1 s/r conflict)