### PR TITLE
fix x86 fputc arguments order

### DIFF
--- a/x86/libmincaml.S
+++ b/x86/libmincaml.S
@@ -63,8 +63,8 @@ min_caml_prerr_byte:
 	pushl	%ebp
 	movl	%esp, %ebp
 	ALIGNSTACK2
-	pushl	%eax
 	pushl	U(min_caml_stderr)
+	pushl	%eax
 	call	U(fputc)
 	movl	%ebp, %esp
 	popl	%ebp


### PR DESCRIPTION
In prerr_byte, I think the order of arguments to fputc is wrong.

man 3 fputc :
```
int fputc(int c, FILE *stream);
```