### PR TITLE
Evaluate comparison operators from left to right

### DIFF
--- a/kNormal.ml
+++ b/kNormal.ml
@@ -85,7 +85,7 @@ let rec g env = function (* K正規化ルーチン本体 (caml2html: knormal_g) *)
       insert_let (g env e1)
         (fun x -> insert_let (g env e2)
             (fun y -> FDiv(x, y), Type.Float))
-  | Syntax.Eq _ | Syntax.LE _ as cmp ->
+  | Syntax.Eq _ | Syntax.LE _ | Syntax.GE _ as cmp ->
       g env (Syntax.If(cmp, Syntax.Bool(true), Syntax.Bool(false)))
   | Syntax.If(Syntax.Not(e1), e2, e3) -> g env (Syntax.If(e1, e3, e2)) (* notによる分岐を変換 (caml2html: knormal_not) *)
   | Syntax.If(Syntax.Eq(e1, e2), e3, e4) ->
@@ -102,6 +102,13 @@ let rec g env = function (* K正規化ルーチン本体 (caml2html: knormal_g) *)
               let e3', t3 = g env e3 in
               let e4', t4 = g env e4 in
               IfLE(x, y, e3', e4'), t3))
+  | Syntax.If(Syntax.GE(e1, e2), e3, e4) ->
+      insert_let (g env e1)
+        (fun x -> insert_let (g env e2)
+            (fun y ->
+              let e3', t3 = g env e3 in
+              let e4', t4 = g env e4 in
+              IfLE(y, x, e3', e4'), t3))
   | Syntax.If(e1, e2, e3) -> g env (Syntax.If(Syntax.Eq(e1, Syntax.Bool(false)), e3, e2)) (* 比較のない分岐を変換 (caml2html: knormal_if) *)
   | Syntax.Let((x, t), e1, e2) ->
       let e1', t1 = g env e1 in

--- a/parser.mly
+++ b/parser.mly
@@ -94,13 +94,13 @@ exp: /* (* ∞Ï»Ã§Œº∞ (caml2html: parser_exp) *) */
 | exp LESS_GREATER exp
     { Not(Eq($1, $3)) }
 | exp LESS exp
-    { Not(LE($3, $1)) }
+    { Not(GE($1, $3)) }
 | exp GREATER exp
     { Not(LE($1, $3)) }
 | exp LESS_EQUAL exp
     { LE($1, $3) }
 | exp GREATER_EQUAL exp
-    { LE($3, $1) }
+    { GE($1, $3) }
 | IF exp THEN exp ELSE exp
     %prec prec_if
     { If($2, $4, $6) }

--- a/syntax.ml
+++ b/syntax.ml
@@ -14,6 +14,7 @@ type t = (* MinCamlの構文を表現するデータ型 (caml2html: syntax_t) *)
   | FDiv of t * t
   | Eq of t * t
   | LE of t * t
+  | GE of t * t
   | If of t * t * t
   | Let of (Id.t * Type.t) * t * t
   | Var of Id.t

--- a/typing.ml
+++ b/typing.ml
@@ -29,6 +29,7 @@ let rec deref_term = function
   | Sub(e1, e2) -> Sub(deref_term e1, deref_term e2)
   | Eq(e1, e2) -> Eq(deref_term e1, deref_term e2)
   | LE(e1, e2) -> LE(deref_term e1, deref_term e2)
+  | GE(e1, e2) -> GE(deref_term e1, deref_term e2)
   | FNeg(e) -> FNeg(deref_term e)
   | FAdd(e1, e2) -> FAdd(deref_term e1, deref_term e2)
   | FSub(e1, e2) -> FSub(deref_term e1, deref_term e2)
@@ -104,7 +105,7 @@ let rec g env e = (* 型推論ルーチン (caml2html: typing_g) *)
         unify Type.Float (g env e1);
         unify Type.Float (g env e2);
         Type.Float
-    | Eq(e1, e2) | LE(e1, e2) ->
+    | Eq(e1, e2) | LE(e1, e2) | GE(e1, e2) ->
         unify (g env e1) (g env e2);
         Type.Bool
     | If(e1, e2, e3) ->


### PR DESCRIPTION
Since `e1 < e2` is currently **syntactically** equal to `not (e2 <= e1)`, `e2` in right hand side is evaluated first(same for `>=`).
This is strange although the order of evaluation is not specified.
I added GE branch to syntax.ml and conversion from `GE(e1, e2)` to `let x = e1 in let y = e2 in LE(y, x)` in kNormal.ml to make it consistent with other comparison operators.