### PR TITLE
copy_int32 -> caml_copy_int_32

### DIFF
--- a/float.c
+++ b/float.c
@@ -11,11 +11,11 @@ typedef union {
 value gethi(value v) {
   dbl d;
   d.d = Double_val(v);
-  return copy_int32(d.i[0]);
+  return caml_copy_int32(d.i[0]);
 }
 
 value getlo(value v) {
   dbl d;
   d.d = Double_val(v);
-  return copy_int32(d.i[1]);
+  return caml_copy_int32(d.i[1]);
 }


### PR DESCRIPTION
The function `copy_int32` is deprecated and has been completely removed from OCaml 5.0.
Note that this PR does not cause any problem to users of OCaml 4.10 becuase OCaml 4.10 supports both `copy_int32` and `caml_copy_int32` (with a warning saying that `copy_int32`  is deprecated).
(Cf. https://github.com/ocaml-multicore/ocaml-multicore/issues/451)